### PR TITLE
[feat#17] Follow, Blog 엔티티 설계

### DIFF
--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -1,0 +1,104 @@
+name: Gemini Code Review
+
+on:
+  push:
+    branches: [ feature/gemini ]
+    paths:
+      - 'backend/**'
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  code-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+
+      - name: Install GoogleGenerativeAI
+        run: |
+          npm install @google/generative-ai
+
+      # PR 이벤트에서의 변경사항 처리
+      - name: Get git diff for PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}"
+          git fetch origin "${{ github.event.pull_request.head.ref }}"
+          git diff --unified=0 "origin/${{ github.event.pull_request.base.ref }}" > "diff.txt"
+          echo "EVENT_TYPE=pull_request" >> $GITHUB_ENV
+
+      # Push 이벤트에서의 변경사항 처리
+      - name: Get git diff for Push
+        if: github.event_name == 'push'
+        run: |
+          git diff --unified=0 HEAD^ HEAD > "diff.txt"
+          echo "EVENT_TYPE=push" >> $GITHUB_ENV
+
+      # Gemini를 사용한 코드 분석
+      - name: Run Gemini-1.5-flash
+        id: gemini_review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const diff_output = fs.readFileSync("diff.txt",'utf8');
+            
+            const { GoogleGenerativeAI } = require("@google/generative-ai");
+            const genAI = new GoogleGenerativeAI("${{ secrets.GEMINI_API_KEY }}");
+            const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash"});
+            
+            // PR과 Push에 따라 다른 프롬프트 사용
+            let prompt;
+            if (process.env.EVENT_TYPE === 'pull_request') {
+              prompt = `Explain in korean. You are a senior software engineer and need to perform a code review based on the results of a given git diff. Review the changed code from different perspectives and let us know if there are any changes that need to be made. If you see any code that needs to be fixed in the result of the git diff, you need to calculate the exact line number by referring to the "@@ -0,0 +0,0 @@" part. The output format is \[{"path":"{ filepath }", "line": { line }, "text": { review comment }, "side": "RIGHT"}\] format must be respected.\n<git diff>${diff_output}</git diff>`;
+            } else {
+              prompt = `Explain in korean. You are a senior software engineer and need to perform a code review based on the results of a given git diff. Provide a detailed review of the code changes, focusing on code quality, readability, performance, and security. Format your response in Markdown with clear headings for each file reviewed.\n<git diff>${diff_output}</git diff>`;
+            }
+            
+            const result = await model.generateContent(prompt);
+            const response = await result.response;
+            const text = response.text();
+            
+            fs.writeFileSync('review_result.txt', text);
+            console.log('Review results saved!');
+
+      # PR 이벤트: 라인별 리뷰 코멘트 추가
+      - name: Format and add PR review comments
+        if: env.EVENT_TYPE == 'pull_request'
+        id: store
+        run: |
+          COMMENT=$(sed '/^```/d' review_result.txt | jq -c .)
+          echo "comment=$COMMENT" >> $GITHUB_OUTPUT
+
+      - name: Add Pull Request Review Comment
+        if: env.EVENT_TYPE == 'pull_request'
+        uses: nbaztec/add-pr-review-comment@v1.0.7
+        with:
+          comments: ${{ steps.store.outputs.comment }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'
+          allow-repeats: false
+
+      # Push 이벤트: 액션 로그에 리뷰 결과 출력 및 아티팩트 업로드
+      - name: Display review results in workflow log
+        if: env.EVENT_TYPE == 'push'
+        run: |
+          echo "===== Gemini Code Review Results ====="
+          cat review_result.txt
+          echo "======================================"
+
+      - name: Upload review results as artifact
+        if: env.EVENT_TYPE == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gemini-code-review
+          path: review_result.txt

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/blog/blog/entity/Blog.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/blog/blog/entity/Blog.java
@@ -1,30 +1,24 @@
 package com.likelion.momentreeblog.domain.blog.blog.entity;
 
 import com.likelion.momentreeblog.domain.user.user.entity.User;
+import com.likelion.momentreeblog.global.jpa.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Getter @Setter
+@Table(name = "blogs")
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Blog {
+public class Blog extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long blogId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    @Column(nullable = false, length = 255)
-    private String blogName;
-
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-
-    private Long viewCount;
-
-    @OneToOne(mappedBy = "blog")
-    private User user;  // 유저가 1:1로 소유
+    private String name;
 }

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/blog/blog/entity/Blog.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/blog/blog/entity/Blog.java
@@ -1,4 +1,30 @@
 package com.likelion.momentreeblog.domain.blog.blog.entity;
 
+import com.likelion.momentreeblog.domain.user.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Blog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long blogId;
+
+    @Column(nullable = false, length = 255)
+    private String blogName;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private Long viewCount;
+
+    @OneToOne(mappedBy = "blog")
+    private User user;  // 유저가 1:1로 소유
 }

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/follower/entity/Follower.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/follower/entity/Follower.java
@@ -1,32 +1,24 @@
 package com.likelion.momentreeblog.domain.user.follower.entity;
 
 import com.likelion.momentreeblog.domain.user.user.entity.User;
+import com.likelion.momentreeblog.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Entity
-@Getter @Setter
+@Table(name = "followers")
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Follower {
+public class Follower extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user_id")
+    private User fromUser;
 
-    // 팔로우한 사람
-    @ManyToOne
-    @JoinColumn(name = "follower_id", nullable = false)
-    private User follower;
-
-    // 팔로우 당한 사람
-    @ManyToOne
-    @JoinColumn(name = "following_id", nullable = false)
-    private User following;
-
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_user_id")
+    private User toUser;
 }

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/follower/entity/Follower.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/follower/entity/Follower.java
@@ -1,4 +1,32 @@
 package com.likelion.momentreeblog.domain.user.follower.entity;
 
+import com.likelion.momentreeblog.domain.user.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Follower {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 팔로우한 사람
+    @ManyToOne
+    @JoinColumn(name = "follower_id", nullable = false)
+    private User follower;
+
+    // 팔로우 당한 사람
+    @ManyToOne
+    @JoinColumn(name = "following_id", nullable = false)
+    private User following;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }


### PR DESCRIPTION
## 작업 내용

- Blog, Follower 엔티티 설계 완료

## 할 일

- [1] Follow 엔티티 추가
follower_id, following_id로 사용자 간 팔로우 관계 정의
User 엔티티와의 양방향 연관관계 설정 (ManyToOne x 2)
- [2] Blog 엔티티 추가
블로그 ID, 이름, 생성일, 수정일, 조회수 필드 포함
User 엔티티와의 단방향 연관관계 설정 (ManyToOne)

## 추가 주의사항

-

## 추가 의논사항

-

## 스크린샷 (필요시)

-
