### PR TITLE
[feat] 게시글 상세보기 기능 구현

### DIFF
--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/board/board/controller/BoardApiV1Controller.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/board/board/controller/BoardApiV1Controller.java
@@ -1,5 +1,6 @@
 package com.likelion.momentreeblog.domain.board.board.controller;
 
+import com.likelion.momentreeblog.domain.board.board.dto.BoardDetailResponseDto;
 import com.likelion.momentreeblog.domain.board.board.dto.BoardListResponseDto;
 import com.likelion.momentreeblog.domain.board.board.dto.BoardRequestDto;
 import com.likelion.momentreeblog.domain.board.board.service.BoardService;
@@ -43,6 +44,23 @@ public class BoardApiV1Controller {
             return ResponseEntity.status(500).body("게시글 작성 실패! " + e.getMessage());
         }
     }
+
+    //게시글 상세보기
+    @Operation(summary = "게시글 상세보기")
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getBoard(@PathVariable Long id) {
+        try {
+            BoardDetailResponseDto board = boardService.getBoardDetail(id);
+            return ResponseEntity.ok(board);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("게시글을 찾을 수 없습니다: " + e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("게시글 조회 실패: " + e.getMessage());
+        }
+    }
+
 
     @PutMapping("/{id}")
     public ResponseEntity<String> updateBoard(

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/board/board/dto/BoardDetailResponseDto.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/board/board/dto/BoardDetailResponseDto.java
@@ -1,0 +1,48 @@
+package com.likelion.momentreeblog.domain.board.board.dto;
+
+import com.likelion.momentreeblog.domain.blog.blog.entity.Blog;
+import com.likelion.momentreeblog.domain.board.board.entity.Board;
+import com.likelion.momentreeblog.domain.board.category.entity.Category;
+import com.likelion.momentreeblog.domain.board.like.entity.Like;
+import com.likelion.momentreeblog.domain.photo.photo.entity.Photo;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class BoardDetailResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private Blog blog;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Category category;
+    private Photo currentMainPhoto;
+    private List<Photo> photos;
+    private List<Like> likes;
+
+    public static BoardDetailResponseDto from(Board board) {
+        return BoardDetailResponseDto.builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .blog(board.getBlog())
+                .createdAt(board.getCreatedAt())
+                .updatedAt(board.getUpdatedAt())
+                .category(board.getCategory())
+                .currentMainPhoto(board.getCurrentMainPhoto())
+                .photos(board.getPhotos())
+                .likes(board.getLikes())
+                .build();
+    }
+}

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/board/board/service/BoardService.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/board/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.likelion.momentreeblog.domain.board.board.service;
 
 import com.likelion.momentreeblog.domain.blog.blog.entity.Blog;
 import com.likelion.momentreeblog.domain.blog.blog.repository.BlogRepository;
+import com.likelion.momentreeblog.domain.board.board.dto.BoardDetailResponseDto;
 import com.likelion.momentreeblog.domain.board.board.dto.BoardListResponseDto;
 import com.likelion.momentreeblog.domain.board.board.dto.BoardRequestDto;
 import com.likelion.momentreeblog.domain.board.board.entity.Board;
@@ -106,12 +107,14 @@ public class BoardService {
                 board.getBlog().getId()
         ));
     }
+    
+public BoardDetailResponseDto getBoardDetail(Long id) {
+    Board board = boardRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
+            
+    blogRepository.findById(board.getBlog().getId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 게시물의 블로그 정보가 존재하지 않습니다."));
 
-
-
-
-
-
-
-
+    return BoardDetailResponseDto.from(board);
+}
 }


### PR DESCRIPTION
## 작업 내용

- 게시글 상세보기 기능 구현

## 할 일

- [1] BoardDetailResponseDto 추가
- [2] Controller, Service 관련 기능 추가
- [3] h2 테스트(완료)
## 추가 주의사항

-

## 추가 의논사항

-

## 스크린샷 (필요시)

-

---
Closes #88 