### PR TITLE
[Feature/#86] 회원정보찾기 - (이름+이메일) 추가

### DIFF
--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/controller/UserFindApiV1Controller.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/controller/UserFindApiV1Controller.java
@@ -49,4 +49,16 @@ public class UserFindApiV1Controller {
             return ResponseEntity.ok(UserResponse.from(user.get()));
         }
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> getUserByNameAndEmail(
+            @RequestParam(name = "name") String name,
+            @RequestParam(name = "email") String email) {
+        Optional<User> user = userFindService.getUserByNameAndEmail(name, email);
+        if(user.isEmpty()) {
+            return ResponseEntity.ok("해당하는 유저를 찾을 수 없습니다.");
+        } else {
+            return ResponseEntity.ok(UserResponse.from(user.get()));
+        }
+    }
 }

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/repository/UserRepository.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/repository/UserRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByName(String name);
+    Optional<User> findByNameAndEmail(String name, String email);
 }
 

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/UserFindService.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/UserFindService.java
@@ -9,6 +9,7 @@ public interface UserFindService {
     Optional<User> getUserById(Long id);
     Optional<User> getUserByEmail(String email);
     Optional<User> getUserByName(String name);
+    Optional<User> getUserByNameAndEmail(String name, String email);
 
     Long getFollowingCount(User user);
     Long getFollowerCount(User user);

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/UserFindServiceImpl.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/UserFindServiceImpl.java
@@ -3,10 +3,10 @@ package com.likelion.momentreeblog.domain.user.user.service;
 import com.likelion.momentreeblog.domain.user.user.entity.User;
 import com.likelion.momentreeblog.domain.user.user.repository.FollowRepository;
 import com.likelion.momentreeblog.domain.user.user.repository.UserFindRepository;
+import com.likelion.momentreeblog.domain.user.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -14,6 +14,7 @@ import java.util.Optional;
 public class UserFindServiceImpl implements UserFindService{
     private final UserFindRepository userFindRepository;
     private final FollowRepository followRepository;
+    private final UserRepository userRepository;
 
     @Override
     public Optional<User> getUserById(Long id) {
@@ -31,6 +32,11 @@ public class UserFindServiceImpl implements UserFindService{
     }
 
     @Override
+    public Optional<User> getUserByNameAndEmail(String name, String email) {
+        return userRepository.findByNameAndEmail(name, email);
+    }
+
+    @Override
     public Long getFollowingCount(User user) {
         return followRepository.countByFollowing(user);
     }
@@ -39,4 +45,5 @@ public class UserFindServiceImpl implements UserFindService{
     public Long getFollowerCount(User user) {
         return followRepository.countByFollower(user);
     }
+
 }


### PR DESCRIPTION
## 작업 내용

- 회원정보찾기로부터 (이름과 이메일)을 함께 입력받는 컨트롤러와 기능 추가

## 할 일

- [1] /search URI로 이름/이메일 동시에 찾는 기능
- [2] UserFIndService 에 관련 기능 추가
- [3] UserRepository 에 관련 기능 추가

## 추가 주의사항

-

## 추가 의논사항

-

## 스크린샷 (필요시)

-

---
Closes #86 
