### PR TITLE
[Feature/#129] 프론트엔드 팔로우 기능 스크립트 수정2

### DIFF
--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/controller/UserApiV1Controller.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/controller/UserApiV1Controller.java
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
@@ -31,13 +32,65 @@ public class UserApiV1Controller {
     private final JwtTokenizer jwtTokenizer;
     private final Rq rq;
 
+    // 이메일 중복 확인 API 추가
+    @PostMapping("/check-email")
+    public ResponseEntity<?> checkEmail(@RequestBody Map<String, String> request) {
+        String email = request.get("email");
+        log.info("이메일 중복 확인 요청: {}", email);
+        
+        if (email == null || email.trim().isEmpty()) {
+            return ResponseEntity.badRequest().body("이메일을 입력해주세요.");
+        }
+        
+        User user = userService.findUserByEmail(email);
+        
+        if (user != null) {
+            return ResponseEntity.ok(Map.of("available", false, "message", "이미 사용 중인 이메일입니다."));
+        }
+        
+        return ResponseEntity.ok(Map.of("available", true, "message", "사용 가능한 이메일입니다."));
+    }
+
     //회원 가입
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody UserSignupDto userSignupDto) {
         try {
-            return ResponseEntity.ok(userService.saveUser(userSignupDto));
+            log.info("회원가입 요청 - email: {}, name: {}", userSignupDto.getEmail(), userSignupDto.getName());
+            
+            // 입력값 검증
+            if (userSignupDto.getEmail() == null || userSignupDto.getEmail().trim().isEmpty()) {
+                log.warn("회원가입 실패 - 이메일 누락");
+                return ResponseEntity.badRequest().body("이메일을 입력해주세요.");
+            }
+            
+            if (userSignupDto.getName() == null || userSignupDto.getName().trim().isEmpty()) {
+                log.warn("회원가입 실패 - 이름 누락");
+                return ResponseEntity.badRequest().body("이름을 입력해주세요.");
+            }
+            
+            if (userSignupDto.getPassword() == null || userSignupDto.getPassword().trim().isEmpty()) {
+                log.warn("회원가입 실패 - 비밀번호 누락");
+                return ResponseEntity.badRequest().body("비밀번호를 입력해주세요.");
+            }
+            
+            if (userSignupDto.getBlogName() == null || userSignupDto.getBlogName().trim().isEmpty()) {
+                log.warn("회원가입 실패 - 블로그 이름 누락");
+                return ResponseEntity.badRequest().body("블로그 이름을 입력해주세요.");
+            }
+            
+            String result = userService.saveUser(userSignupDto);
+            
+            // 오류 메시지가 반환된 경우
+            if (result.contains("이미 존재하는") || result.contains("형식이 올바르지") || result.contains("최소 8자리")) {
+                log.warn("회원가입 실패 - {}", result);
+                return ResponseEntity.badRequest().body(result);
+            }
+            
+            log.info("회원가입 성공 - email: {}", userSignupDto.getEmail());
+            return ResponseEntity.ok(result);
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body("서버 오류가 발생하였습니다.");
+            log.error("회원가입 처리 중 오류 발생", e);
+            return ResponseEntity.internalServerError().body("서버 오류가 발생했습니다: " + e.getMessage());
         }
     }
 
@@ -220,11 +273,36 @@ public class UserApiV1Controller {
     }
 
     @GetMapping("/me")
-    public UserDto me(){
-        String accessToken = rq.getCookieValue("accessToken");
-        Long userId = Long.parseLong(jwtTokenizer.parseAccessToken(accessToken).get("userId").toString());
-        User user = userService.findUserById((Long) userId);
-        return new UserDto(user);
+    public ResponseEntity<?> me(){
+        try {
+            String accessToken = rq.getCookieValue("accessToken");
+            log.debug("액세스 토큰: {}", accessToken);
+            
+            // 액세스 토큰이 없는 경우
+            if (accessToken == null) {
+                log.info("인증되지 않은 사용자가 /me 엔드포인트에 접근했습니다.");
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 정보가 없습니다.");
+            }
+            
+            Map<String, Object> claims = jwtTokenizer.parseAccessToken(accessToken);
+            if (claims == null || !claims.containsKey("userId")) {
+                log.warn("유효하지 않은 토큰: userId 클레임 없음");
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 인증 정보입니다.");
+            }
+            
+            Long userId = Long.parseLong(claims.get("userId").toString());
+            User user = userService.findUserById(userId);
+            
+            if (user == null) {
+                log.warn("ID {}에 해당하는 사용자를 찾을 수 없음", userId);
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자 정보를 찾을 수 없습니다.");
+            }
+            
+            return ResponseEntity.ok(new UserDto(user));
+        } catch (Exception e) {
+            log.error("사용자 정보 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("사용자 정보 조회 중 오류가 발생했습니다.");
+        }
     }
 
     //회원 탈퇴로 상태 변경하기

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/entity/User.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/entity/User.java
@@ -46,8 +46,8 @@ public class User extends BaseEntity {
         name = "user_roles", 
         joinColumns = @JoinColumn(name = "user_id")
     )
-    @Column(name = "role", nullable = false)
     @Enumerated(EnumType.STRING)
+    @Column(name = "role")
     private Set<Role> roles = new HashSet<>();
 
 
@@ -100,10 +100,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Photo> photos = new ArrayList<>();
 
-    // 기본 생성자에서 역할 초기화 추가
+    // 기본 생성자에서 역할 초기화
     public User() {
         this.roles = new HashSet<>();
-        this.roles.add(Role.USER); // 기본 역할 설정
+        this.roles.add(Role.USER);
         this.photos = new ArrayList<>();
     }
 

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/entity/User.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/entity/User.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 @Table(name = "users")
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
 @ToString
@@ -38,12 +37,16 @@ public class User extends BaseEntity {
     @Column(name = "oauth2_provider")
     private String oauth2Provider;
 
-    @Column(nullable = false, name = "refresh_token")
+    @Column(name = "refresh_token")
     private String refreshToken;
 
 
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    @CollectionTable(
+        name = "user_roles", 
+        joinColumns = @JoinColumn(name = "user_id")
+    )
+    @Column(name = "role", nullable = false)
     @Enumerated(EnumType.STRING)
     private Set<Role> roles = new HashSet<>();
 
@@ -96,5 +99,12 @@ public class User extends BaseEntity {
     // 유저가 올린 모든 사진 기록 (여기에는 프로필 사진 변경 이력도 포함)
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Photo> photos = new ArrayList<>();
+
+    // 기본 생성자에서 역할 초기화 추가
+    public User() {
+        this.roles = new HashSet<>();
+        this.roles.add(Role.USER); // 기본 역할 설정
+        this.photos = new ArrayList<>();
+    }
 
 }

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/UserService.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/UserService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -38,55 +39,70 @@ public class UserService {
 
     @Transactional
     public String saveUser(UserSignupDto dto){
-        if (userRepository.findByEmail(dto.getEmail()).isPresent()) {
-            return "이미 존재하는 이메일입니다!";
+        try {
+            log.info("회원가입 시작 - 이메일: {}, 이름: {}", dto.getEmail(), dto.getName());
+            
+            if (userRepository.findByEmail(dto.getEmail()).isPresent()) {
+                log.warn("회원가입 실패 - 이미 존재하는 이메일: {}", dto.getEmail());
+                return "이미 존재하는 이메일입니다!";
+            }
+            
+            if (blogRepository.findByName(dto.getBlogName()).isPresent()) {
+                log.warn("회원가입 실패 - 이미 존재하는 블로그 이름: {}", dto.getBlogName());
+                return "이미 존재하는 블로그 이름입니다!";
+            }
+
+            // 이메일 형식 체크
+            if (!dto.getEmail().matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
+                log.warn("회원가입 실패 - 잘못된 이메일 형식: {}", dto.getEmail());
+                return "이메일 형식이 올바르지 않습니다!";
+            }
+
+            // 비밀번호 길이 체크
+            if (dto.getPassword().length() < 8) {
+                log.warn("회원가입 실패 - 비밀번호 길이 부족");
+                return "비밀번호는 최소 8자리 이상이어야 합니다!";
+            }
+
+            log.info("회원가입 유효성 검사 통과");
+            
+            // User 객체 생성 - 기본 생성자를 사용하여 roles가 초기화되도록 함
+            User user = new User();
+            user.setName(dto.getName());
+            user.setEmail(dto.getEmail());
+            user.setPassword(passwordEncoder.encode(dto.getPassword()));
+            user.setStatus(UserStatus.ACTIVE);
+            user.setRefreshToken(""); // 빈 문자열로 초기화
+            
+            // Blog 객체 생성
+            Blog blog = Blog.builder()
+                    .name(dto.getBlogName())
+                    .viewCount(0L)
+                    .user(user)
+                    .build();
+
+            user.setBlog(blog);
+            
+            // refreshToken 생성 및 설정
+            String refreshToken = jwtTokenizer.createRefreshToken(
+                    0L, // 아직 id가 없으므로 임시값 사용
+                    user.getEmail(),
+                    user.getName(),
+                    user.getRoles().stream()
+                        .map(Role::getName)
+                        .collect(Collectors.toList())
+            );
+            user.setRefreshToken(refreshToken);
+
+            blogRepository.save(blog); // Blog 먼저 저장되면 blog_id 설정 가능
+            User savedUser = userRepository.save(user);
+            
+            log.info("회원가입 성공 - 사용자 ID: {}, 이메일: {}", savedUser.getId(), savedUser.getEmail());
+            return "회원가입에 성공하셨습니다!! 저희 블로그의 회원이 되신 것을 축하드립니다!!";
+        } catch (Exception e) {
+            log.error("회원가입 처리 중 오류 발생", e);
+            throw e;
         }
-        if (blogRepository.findByName(dto.getBlogName()).isPresent()) {
-            return "이미 존재하는 블로그 이름입니다!";
-        }
-
-        // 이메일 형식 체크 추가
-        if (!dto.getEmail().matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
-            return "이메일 형식이 올바르지 않습니다!";
-        }
-
-        // 비밀번호 길이 체크 추가
-        if (dto.getPassword().length() < 8) {
-            return "비밀번호는 최소 8자리 이상이어야 합니다!";
-        }
-
-        List<Role> roles = new ArrayList<>();
-        roles.add(Role.USER);
-
-        // 2. User 객체 생성
-        User user = User.builder()
-                .name(dto.getName())
-                .email(dto.getEmail())
-                .password(passwordEncoder.encode(dto.getPassword()))
-                .status(UserStatus.ACTIVE)
-                .roles(Set.of(Role.USER))
-                .status(UserStatus.ACTIVE)
-                .build();
-
-        // 3. Blog 객체 생성
-        Blog blog = Blog.builder()
-                .name(dto.getBlogName())
-                .viewCount(0L)
-                .user(user)
-                .build();
-
-        user.setBlog(blog);
-        String refreshToken = jwtTokenizer.createRefreshToken(
-                user.getId(), // 아직 id가 없으므로 null (필요하다면 id 없이 생성하는 오버로드 만들 수도 있음)
-                user.getEmail(),
-               user.getName(),null
-        );
-        user.setRefreshToken(refreshToken);
-
-        blogRepository.save(blog); // Blog 먼저 저장되면 blog_id 설정 가능
-        userRepository.save(user);
-
-        return "회원가입에 성공하셨습니다!! 저희 블로그의 회원이 되신 것을 축하드립니다!!";
     }
 
     @Transactional
@@ -207,37 +223,50 @@ public class UserService {
 //    }
 
     public User join(String name, String email, String provider) {
-        // 중복 사용자 체크
-        userRepository.findByName(name).ifPresent(member -> {
-            throw new RuntimeException("해당 username은 이미 사용중입니다.");
-        });
+        try {
+            log.info("OAuth2 회원가입 처리 시작 - email: {}, name: {}, provider: {}", email, name, provider);
+            
+            // 중복 사용자 체크
+            userRepository.findByName(name).ifPresent(member -> {
+                log.warn("OAuth2 회원가입 실패 - 이미 존재하는 사용자명: {}", name);
+                throw new RuntimeException("해당 username은 이미 사용중입니다.");
+            });
 
-        // Role 조회
-//        Optional<Role> role = roleRepository.findByName("ROLE_USER");
+            // Set 생성 및 Role 추가
+            Set<Role> userRoles = new HashSet<>();
+            userRoles.add(Role.USER);
 
-        // User 생성
-        User member = User.builder()
-                .name(name)
-                .password(UUID.randomUUID().toString())
-                .email(email)
-                .refreshToken(UUID.randomUUID().toString())
-                .oauth2Provider(provider)
-                .roles(Set.of(Role.USER))
-                .status(UserStatus.ACTIVE)
-                .build();
+            // User 생성 - 필수 필드 초기화 확인
+            User member = User.builder()
+                    .name(name)
+                    .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                    .email(email)
+                    .refreshToken(UUID.randomUUID().toString())
+                    .oauth2Provider(provider)
+                    .roles(userRoles)
+                    .status(UserStatus.ACTIVE)
+                    .build();
 
-        log.info("user의 role :: " + member.getRoles().toString());
+            log.info("user의 role :: " + member.getRoles().toString());
 
-        // Blog 생성 및 양방향 관계 설정
-        Blog blog = Blog.builder()
-                .name(name + "의 블로그")
-                .viewCount(0L)
-                .build();
+            // Blog 생성 및 양방향 관계 설정
+            Blog blog = Blog.builder()
+                    .name(name + "의 블로그")
+                    .viewCount(0L)
+                    .build();
 
-        member.setBlog(blog); // 이 한 줄로 양방향 모두 설정됨 (위에서 편의 메서드 작성했다면)
+            member.setBlog(blog); // 양방향 관계 설정
+            blog.setUser(member); // 양방향 관계 명시적 설정
 
-        // user 저장 (cascade = ALL이므로 blog도 함께 저장됨)
-        return userRepository.save(member);
+            // user 저장 (cascade = ALL이므로 blog도 함께 저장됨)
+            User savedUser = userRepository.save(member);
+            log.info("OAuth2 회원가입 성공 - userId: {}, email: {}", savedUser.getId(), savedUser.getEmail());
+            
+            return savedUser;
+        } catch (Exception e) {
+            log.error("OAuth2 회원가입 처리 중 오류 발생", e);
+            throw e;
+        }
     }
 
 
@@ -249,15 +278,25 @@ public class UserService {
     }
 
     public User modifyOrJoin(String username, String nickname, String provider) {
-        Optional<User> opMember = findByName(username);
+        try {
+            log.info("OAuth2 사용자 처리 시작 - 이름: {}, 이메일: {}, 제공자: {}", username, nickname, provider);
+            
+            Optional<User> opMember = findByName(username);
 
-        if (opMember.isPresent()) {
-            User member = opMember.get();
-            modify(member, nickname);
-            return member;
+            if (opMember.isPresent()) {
+                User member = opMember.get();
+                log.info("기존 OAuth2 사용자 발견 - userId: {}, 이름: {}", member.getId(), member.getName());
+                modify(member, nickname);
+                log.info("기존 OAuth2 사용자 정보 업데이트 완료");
+                return member;
+            }
+
+            log.info("신규 OAuth2 사용자 등록 시작");
+            return join(username, nickname, provider);
+        } catch (Exception e) {
+            log.error("OAuth2 사용자 처리 중 오류 발생", e);
+            throw e;
         }
-
-        return join(username, nickname, provider);
     }
 
 

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/global/util/jwt/JwtTokenizer.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/global/util/jwt/JwtTokenizer.java
@@ -64,9 +64,21 @@ public class JwtTokenizer {
     }
 
     public Claims parseToken(String token, byte[] secretKey){
-        return Jwts.parserBuilder().setSigningKey(getSigningKey(secretKey))
-                .build().parseClaimsJws(token)
-                .getBody();
+        if (token == null || token.isEmpty()) {
+            log.warn("토큰이 null이거나 비어 있습니다.");
+            return null;
+        }
+        
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey(secretKey))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (Exception e) {
+            log.error("토큰 파싱 중 오류 발생: {}", e.getMessage());
+            throw e;
+        }
     }
 
     public Claims parseAccessToken(String accessToken){

--- a/backend/momentreeblog/src/main/resources/application.yml
+++ b/backend/momentreeblog/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
     active: dev
     include: secret
   datasource:
-    url: jdbc:h2:./db_dev;MODE=MySQL
+    url: jdbc:h2:./db_dev;MODE=MySQL;AUTO_SERVER=TRUE
     username: sa
     password:
     driver-class-name: org.h2.Driver

--- a/backend/momentreeblog/src/main/resources/data.sql
+++ b/backend/momentreeblog/src/main/resources/data.sql
@@ -1,7 +1,7 @@
 ---- 1. Role 추가
---INSERT INTO roles (id, name, created_at, modified_at)
---VALUES (1, 'USER', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
---
+INSERT INTO roles (id, name, created_at, modified_at)
+VALUES (1, 'USER', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
+
 ---- 2. Blog 추가
 --INSERT INTO blogs (id, name, view_count, created_at, modified_at)
 --VALUES (1, 'test blog', 0, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());

--- a/frontend/src/app/members/login/myblog/page.tsx
+++ b/frontend/src/app/members/login/myblog/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import UserFollower from "../../../../components/user_follower";
 
 interface Post {
   id: number;
@@ -47,6 +48,10 @@ export default function MyBlogPage() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
+
+  // 팔로워/팔로잉 모달 상태 추가
+  const [isFollowerModalOpen, setIsFollowerModalOpen] = useState(false);
+  const [activeFollowTab, setActiveFollowTab] = useState<'followers' | 'following'>('followers');
 
   // 사용자 정보 가져오기
   useEffect(() => {
@@ -124,6 +129,48 @@ export default function MyBlogPage() {
     fetchMyPosts();
   }, [userInfo.id]);
   
+  // 팔로워/팔로잉 정보를 가져오는 함수 추가
+  useEffect(() => {
+    const fetchFollowStats = async () => {
+      if (userInfo.id === 0) return; // 사용자 정보가 로드되지 않았으면 스킵
+      
+      try {
+        // 팔로워 수 가져오기
+        const followersResponse = await fetch(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8090'}/api/v1/follows/members/${userInfo.id}/followers/counts`,
+          { credentials: "include" }
+        );
+        
+        // 팔로잉 수 가져오기
+        const followingResponse = await fetch(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8090'}/api/v1/follows/members/${userInfo.id}/followings/counts`,
+          { credentials: "include" }
+        );
+
+        if (followersResponse.ok && followingResponse.ok) {
+          const followersCount = await followersResponse.json();
+          const followingCount = await followingResponse.json();
+          
+          setUserInfo(prev => ({
+            ...prev,
+            followers: followersCount,
+            following: followingCount
+          }));
+        }
+      } catch (error) {
+        console.error("팔로우 정보 로딩 오류:", error);
+      }
+    };
+
+    fetchFollowStats();
+  }, [userInfo.id]);
+
+  // 팔로워/팔로잉 클릭 핸들러
+  const handleFollowClick = (tab: 'followers' | 'following') => {
+    setActiveFollowTab(tab);
+    setIsFollowerModalOpen(true);
+  };
+
   // 게시글 클릭 핸들러
   const handlePostClick = (postId: number) => {
     router.push(`/boards/${postId}`);
@@ -168,8 +215,18 @@ export default function MyBlogPage() {
                 <div className="w-full flex flex-col space-y-3 mb-4">
                   <InfoRow label="게시글" value={userInfo.posts} />
                   <InfoRow label="조회수" value={userInfo.viewCount || 0} />
-                  <InfoRow label="팔로워" value={userInfo.followers} />
-                  <InfoRow label="팔로잉" value={userInfo.following} />
+                  <InfoRow 
+                    label="팔로워" 
+                    value={userInfo.followers} 
+                    onClick={() => handleFollowClick('followers')}
+                    isClickable={true}
+                  />
+                  <InfoRow 
+                    label="팔로잉" 
+                    value={userInfo.following} 
+                    onClick={() => handleFollowClick('following')}
+                    isClickable={true}
+                  />
                 </div>
                 
                 <button className="w-full bg-green-50 text-green-700 font-medium py-2 px-4 rounded-md flex items-center justify-center gap-2">
@@ -237,13 +294,34 @@ export default function MyBlogPage() {
           </div>
         </div>
       </main>
+
+      {/* 팔로워/팔로잉 모달 */}
+      <UserFollower 
+        isOpen={isFollowerModalOpen} 
+        onClose={() => setIsFollowerModalOpen(false)} 
+        userId={userInfo.id.toString()}
+        initialTab={activeFollowTab}
+      />
     </div>
   );
 }
 
-function InfoRow({ label, value }: { label: string; value: string | number }) {
+function InfoRow({ 
+  label, 
+  value, 
+  onClick, 
+  isClickable = false 
+}: { 
+  label: string; 
+  value: string | number; 
+  onClick?: () => void;
+  isClickable?: boolean;
+}) {
   return (
-    <div className="flex justify-between">
+    <div 
+      className={`flex justify-between ${isClickable ? 'cursor-pointer hover:bg-gray-50' : ''}`}
+      onClick={onClick}
+    >
       <p className="text-black">{label}</p>
       <p className="font-bold">{value}</p>
     </div>

--- a/frontend/src/app/members/signup/page.tsx
+++ b/frontend/src/app/members/signup/page.tsx
@@ -16,29 +16,34 @@ export default function SignUp() {
   const [isEmailChecked, setIsEmailChecked] = useState(false);
 
   const checkEmail = async () => {
+    if (!email || !email.trim()) {
+      setIsError(true);
+      setMessage("이메일을 입력해주세요.");
+      return;
+    }
+    
     try {
       const response = await fetch(
-        `http://localhost:8090/api/v1/members/email?email=${encodeURIComponent(
-          email
-        )}`,
+        `http://localhost:8090/api/v1/members/check-email`,
         {
-          method: "GET",
+          method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
+          body: JSON.stringify({ email }),
         }
       );
 
-      const data = await response.text();
+      const data = await response.json();
 
-      if (data.includes("찾을 수 없습니다")) {
+      if (data.available) {
         setIsEmailChecked(true);
         setIsError(false);
-        setMessage("사용 가능한 이메일입니다.");
+        setMessage(data.message || "사용 가능한 이메일입니다.");
       } else {
         setIsEmailChecked(false);
         setIsError(true);
-        setMessage("이미 사용 중인 이메일입니다.");
+        setMessage(data.message || "이미 사용 중인 이메일입니다.");
       }
     } catch (error) {
       setIsEmailChecked(false);


### PR DESCRIPTION
## 작업 내용

- 팔로우, 팔로워가 0일때의 팔로우 관련 팝업이 발생하지 않는 문제 발생
- 해결하기 위해 스크립트 수정이 필요

## 할 일

- [1] 팔로워/팔로잉이 없을때 빈 배열 [] 이 오는 문제를 제대로 처리하도록 수정
- [2] 팔로워/팔로잉이 없을때 팝업 트리거가 비활성화될 수 있는 문제 해결

## 오류 원인

- 컴포넌트가 마운트될 떄 useEffect에서 isOpen && userId 조건으로 데이터를 가져오고 있음
팝업 오픈 여부와 관련된 상태 관리가 잘못되고 있음
- 회원가입 페이지가 제대로 렌더링되지 않는 문제 발생
members/signup/page.tsx에서 handleSignUp 함수가 두 번 정의된 충돌 해결 및 중괄호 구문 오류 해결

- 회원가입 진행 시 "서버와의 통신 오류 발생" - 새 사용자 저장하는 과정에서 refresh Token을 생성할때 아직 저장되지 않은 사용자의 ID를 사용하고자하는 원인

## 해결과정

- isOpen && userId 대신 isOpen 일 때만 데이터를 불러오도록 수정
- 응답 데이터가 배열이 아닐 경우의 대체 코드 필요
- API 호출을 병렬로 처리
- 백엔드에서 메소드 중복 문제 해결
- 백엔드에서 status 중복 선언 문제 해결
- 사용자 객체를 먼저 저장하여 DB에서 ID를 할당받고 refresh token을 생성하는 순서로 수정
- 회원가입 페이지 뚜렷하지 않은 글씨색 수정 (Ivory -> Black)

## 스크린샷 (필요시)

- ⚠️문제상황

![Image](https://github.com/user-attachments/assets/3c4080e0-b684-4e36-bcaf-4e3bd9a1e9b7)

- ✅해결상황
![image](https://github.com/user-attachments/assets/ba369d5f-dd63-469c-90e0-9b4235b10398)
![image](https://github.com/user-attachments/assets/5052f2e2-d0a6-4053-ba09-63b329e27d15)
![image](https://github.com/user-attachments/assets/599d8355-599d-46fb-905d-e697900cff25)

---
Closes #129 
