### PR TITLE
[Refactor/#129] 프론트엔드 팔로워/팔로잉 기능 팝업 API 완료

### DIFF
--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/controller/FollowApiV1Controller.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/controller/FollowApiV1Controller.java
@@ -25,27 +25,41 @@ public class FollowApiV1Controller {
     private final FollowService followService;
     private final JwtTokenizer jwtTokenizer;
 
-    // 특정 유저 팔로워 수 조회
-    @Operation(summary = "팔로잉 수 조회", description = "특정 유저의 팔로워 수를 조회합니다.")
-    @GetMapping("/members/{id}/followings/counts")
-    public ResponseEntity<?> getFollowerCount(@PathVariable(name="id") Long id){
-        Optional<User> user = userFindService.getUserById(id);
+    // 특정 유저의 팔로잉 목록 조회
+    @GetMapping("/members/{userId}/followings")
+    public ResponseEntity<List<UserFollowDto>> listFollowings(@PathVariable(name = "userId") Long userId) {
+        List<UserFollowDto> list = followService.getFollowings(userId);
+        return ResponseEntity.ok(list);
+    }
+
+    // 특정 유저의 팔로워 목록 조회
+    @GetMapping("/members/{userId}/followers")
+    public ResponseEntity<List<UserFollowDto>> listFollowers(@PathVariable Long userId) {
+        List<UserFollowDto> list = followService.getFollowers(userId);
+        return ResponseEntity.ok(list);
+    }
+
+    // 특정 유저의 팔로워 수 조회
+    @Operation(summary = "팔로워 수 조회", description = "특정 유저의 팔로워 수를 조회합니다.")
+    @GetMapping("/members/{userId}/followers/counts")
+    public ResponseEntity<?> getFollowerCount(@PathVariable Long userId) {
+        Optional<User> user = userFindService.getUserById(userId);
         if(user.isEmpty()) {
             return ResponseEntity.ok("유저를 찾을 수 없습니다.");
-        }else {
+        } else {
             long count = userFindService.getFollowerCount(user.get());
             return ResponseEntity.ok(count);
         }
     }
 
     // 특정 유저의 팔로잉 수 조회
-    @Operation(summary = "팔로워 수 조회", description = "특정 유저의 팔로잉 수를 조회합니다.")
-    @GetMapping("/members/{id}/followers/counts")
-    public ResponseEntity<?> getFollowingCount(@PathVariable(name="id") Long id){
-        Optional<User> user = userFindService.getUserById(id);
+    @Operation(summary = "팔로잉 수 조회", description = "특정 유저의 팔로잉 수를 조회합니다.")
+    @GetMapping("/members/{userId}/followings/counts")
+    public ResponseEntity<?> getFollowingCount(@PathVariable Long userId) {
+        Optional<User> user = userFindService.getUserById(userId);
         if(user.isEmpty()) {
             return ResponseEntity.ok("유저를 찾을 수 없습니다.");
-        }else {
+        } else {
             long count = userFindService.getFollowingCount(user.get());
             return ResponseEntity.ok(count);
         }
@@ -81,7 +95,6 @@ public class FollowApiV1Controller {
             return ResponseEntity.status(400).body("이미 팔로우 중인 유저입니다.");
         }
     }
-
 
     @Operation(summary = "팔로우 취소 (언팔로우)", description = "팔로우를 취소합니다.")
     @DeleteMapping("/unfollow")
@@ -124,17 +137,5 @@ public class FollowApiV1Controller {
         User following = userFindService.getUserById(followingId).get();
         boolean result = followService.isFollowing(follower, following);
         return ResponseEntity.ok(result);
-    }
-
-    @GetMapping("/members/{id}/followers")
-    public ResponseEntity<List<UserFollowDto>> listFollowers(@PathVariable Long userId) {
-        List<UserFollowDto> list = followService.getFollowers(userId);
-        return ResponseEntity.ok(list);
-    }
-
-    @GetMapping("/members/{id}/followings")
-    public ResponseEntity<List<UserFollowDto>> listFollowings(@PathVariable Long userId) {
-        List<UserFollowDto> list = followService.getFollowings(userId);
-        return ResponseEntity.ok(list);
     }
 }

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/repository/FollowRepository.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/repository/FollowRepository.java
@@ -3,6 +3,8 @@ package com.likelion.momentreeblog.domain.user.user.repository;
 import com.likelion.momentreeblog.domain.user.follower.entity.FollowManagement;
 import com.likelion.momentreeblog.domain.user.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,9 +24,11 @@ public interface FollowRepository extends JpaRepository<FollowManagement, Long> 
     // 언팔로우 (삭제 메소드)
     void deleteByFollowerAndFollowing(User follower, User following);
 
-    // followerId로 검색
-    List<FollowManagement> findAllByFollowerId(Long followerId);
+    // followerId로 검색 (내가 팔로우하는 사람들)
+    @Query("SELECT fm FROM FollowManagement fm WHERE fm.follower.id = :followerId")
+    List<FollowManagement> findAllByFollowerId(@Param("followerId") Long followerId);
 
-    // followingId로 검색
-    List<FollowManagement> findAllByFollowingId(Long followingId);
+    // followingId로 검색 (나를 팔로우하는 사람들)
+    @Query("SELECT fm FROM FollowManagement fm WHERE fm.following.id = :followingId")
+    List<FollowManagement> findAllByFollowingId(@Param("followingId") Long followingId);
 }

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/FollowServiceImpl.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/FollowServiceImpl.java
@@ -59,6 +59,7 @@ public class FollowServiceImpl implements FollowService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<UserFollowDto> getFollowings(Long myUserId) {
 
         // 내 팔로잉 목록 가져오기
@@ -80,6 +81,7 @@ public class FollowServiceImpl implements FollowService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<UserFollowDto> getFollowers(Long myUserId) {
 
         // 나를 팔로우 한 사람들의 목록 가져오기

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/FollowServiceImpl.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/FollowServiceImpl.java
@@ -44,12 +44,9 @@ public class FollowServiceImpl implements FollowService {
             throw new IllegalArgumentException("팔로워나 팔로잉이 null입니다.");
         }
 
-        Optional<FollowManagement> follow = followRepository.findByFollowerAndFollowing(follower, following);
-        if (follow.isPresent()) {
-            followRepository.delete(follow.get());
-        } else {
-            log.warn("팔로우 관계가 존재하지 않습니다: follower={}, following={}", follower.getId(), following.getId());
-        }
+        // 단방향 관계만 삭제하도록 deleteByFollowerAndFollowing 사용
+        followRepository.deleteByFollowerAndFollowing(follower, following);
+        log.info("언팔로우 성공: follower={}, following={}", follower.getId(), following.getId());
     }
 
     @Override

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/FollowServiceImpl.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/FollowServiceImpl.java
@@ -61,21 +61,17 @@ public class FollowServiceImpl implements FollowService {
     @Override
     @Transactional(readOnly = true)
     public List<UserFollowDto> getFollowings(Long myUserId) {
-
-        // 내 팔로잉 목록 가져오기
-        List<FollowManagement> following =
-                followRepository.findAllByFollowerId(myUserId);
-
-        // 삭제 필터를 거쳐서 팔로윙 가져오기
-        return following.stream()
-                .map(FollowManagement::getFollowing)         // User 객체
-                .filter(u -> u.getStatus() != UserStatus.DELETED)
-                .map(u -> new UserFollowDto(
-                        u.getId(),
-                        u.getName(),
-                        u.getStatus(),
-                        u.getCurrentProfilePhoto()
-
+        // 내가 팔로우하는 사람들 목록을 가져옴 (followerId가 myUserId)
+        List<FollowManagement> followings = followRepository.findAllByFollowerId(myUserId);
+        
+        return followings.stream()
+                .map(FollowManagement::getFollowing)
+                .filter(user -> user.getStatus() != UserStatus.DELETED)
+                .map(user -> new UserFollowDto(
+                        user.getId(),
+                        user.getName(),
+                        user.getStatus(),
+                        user.getCurrentProfilePhoto()
                 ))
                 .collect(Collectors.toList());
     }
@@ -83,20 +79,17 @@ public class FollowServiceImpl implements FollowService {
     @Override
     @Transactional(readOnly = true)
     public List<UserFollowDto> getFollowers(Long myUserId) {
-
-        // 나를 팔로우 한 사람들의 목록 가져오기
-        List<FollowManagement> followers =
-                followRepository.findAllByFollowingId(myUserId);
-
-        // 삭제 필터를 거쳐서 나를 팔로우한 사람들 가져오기
+        // 나를 팔로우하는 사람들 목록을 가져옴 (followingId가 myUserId)
+        List<FollowManagement> followers = followRepository.findAllByFollowingId(myUserId);
+        
         return followers.stream()
                 .map(FollowManagement::getFollower)
-                .filter(u -> u.getStatus() != UserStatus.DELETED)
-                .map(u -> new UserFollowDto(
-                        u.getId(),
-                        u.getName(),
-                        u.getStatus(),
-                        u.getCurrentProfilePhoto()
+                .filter(user -> user.getStatus() != UserStatus.DELETED)
+                .map(user -> new UserFollowDto(
+                        user.getId(),
+                        user.getName(),
+                        user.getStatus(),
+                        user.getCurrentProfilePhoto()
                 ))
                 .collect(Collectors.toList());
     }

--- a/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/UserFindServiceImpl.java
+++ b/backend/momentreeblog/src/main/java/com/likelion/momentreeblog/domain/user/user/service/UserFindServiceImpl.java
@@ -38,12 +38,24 @@ public class UserFindServiceImpl implements UserFindService{
 
     @Override
     public Long getFollowingCount(User user) {
-        return followRepository.countByFollowing(user);
+        // 팔로잉 수 (내가 팔로우하는 사람 수)를 가져오려면 followRepository.countByFollower를 호출해야 함
+        return followRepository.countByFollower(user);
     }
 
     @Override
     public Long getFollowerCount(User user) {
-        return followRepository.countByFollower(user);
+        // 팔로워 수 (나를 팔로우하는 사람 수)를 가져오려면 followRepository.countByFollowing를 호출해야 함
+        return followRepository.countByFollowing(user);
     }
+
+    // @Override
+    // public Long getFollowingCount(User user) {
+    //     return followRepository.countByFollowing(user);
+    // }
+
+    // @Override
+    // public Long getFollowerCount(User user) {
+    //     return followRepository.countByFollower(user);
+    // }
 
 }

--- a/frontend/src/components/user_follower.tsx
+++ b/frontend/src/components/user_follower.tsx
@@ -1,24 +1,32 @@
-import React, { useState, useEffect } from 'react';
-import Image from 'next/image';
+import React, { useState, useEffect } from "react";
+import Image from "next/image";
 
 interface UserFollowerProps {
   isOpen: boolean;
   onClose: () => void;
   userId?: string; // 현재 보고 있는 프로필의 사용자 ID
-  initialTab?: 'followers' | 'following'; // 초기 선택 탭
+  initialTab?: "followers" | "following"; // 초기 선택 탭
 }
 
 interface User {
   id: string;
   name: string;
-  username: string;
-  imageUrl: string;
-  isFollowing: boolean;
+  status: string;
+  currentProfilePhoto?: {
+    url: string;
+  } | null;
 }
 
-const UserFollower: React.FC<UserFollowerProps> = ({ isOpen, onClose, userId, initialTab = 'followers' }) => {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [activeTab, setActiveTab] = useState<'followers' | 'following'>(initialTab);
+const UserFollower: React.FC<UserFollowerProps> = ({
+  isOpen,
+  onClose,
+  userId,
+  initialTab = "followers",
+}) => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeTab, setActiveTab] = useState<"followers" | "following">(
+    initialTab
+  );
   const [followers, setFollowers] = useState<User[]>([]);
   const [following, setFollowing] = useState<User[]>([]);
   const [loading, setLoading] = useState(false);
@@ -35,30 +43,36 @@ const UserFollower: React.FC<UserFollowerProps> = ({ isOpen, onClose, userId, in
     setLoading(true);
     try {
       // 팔로워 목록 가져오기
-      const followersResponse = await fetch(`http://localhost:8090/api/v1/follows/members/${userId}/followers`, {
-        credentials: 'include'
-      });
-      
+      const followersResponse = await fetch(
+        `http://localhost:8090/api/v1/follows/members/${userId}/followers`,
+        {
+          credentials: "include",
+        }
+      );
+
       // 팔로잉 목록 가져오기
-      const followingResponse = await fetch(`http://localhost:8090/api/v1/follows/members/${userId}/following`, {
-        credentials: 'include'
-      });
+      const followingResponse = await fetch(
+        `http://localhost:8090/api/v1/follows/members/${userId}/followings`,
+        {
+          credentials: "include",
+        }
+      );
 
       if (followersResponse.ok) {
         const followersData = await followersResponse.json();
-        setFollowers(Array.isArray(followersData) ? followersData : []);
+        setFollowers(followersData);
       } else {
         setFollowers([]);
       }
 
       if (followingResponse.ok) {
         const followingData = await followingResponse.json();
-        setFollowing(Array.isArray(followingData) ? followingData : []);
+        setFollowing(followingData);
       } else {
         setFollowing([]);
       }
     } catch (error) {
-      console.error('Failed to fetch follow data:', error);
+      console.error("Failed to fetch follow data:", error);
       setFollowers([]);
       setFollowing([]);
     } finally {
@@ -69,40 +83,44 @@ const UserFollower: React.FC<UserFollowerProps> = ({ isOpen, onClose, userId, in
   // 팔로우/언팔로우 처리 함수
   const handleFollowToggle = async (targetUserId: string) => {
     try {
-      const isCurrentlyFollowing = activeTab === 'following' 
-        ? following.find(user => user.id === targetUserId)?.isFollowing
-        : followers.find(user => user.id === targetUserId)?.isFollowing;
+      const isCurrentlyFollowing =
+        activeTab === "following"
+          ? following.find((user) => user.id === targetUserId)?.isFollowing
+          : followers.find((user) => user.id === targetUserId)?.isFollowing;
 
-      const method = isCurrentlyFollowing ? 'DELETE' : 'POST';
-      const endpoint = isCurrentlyFollowing ? '/unfollow' : '/follow';
-      
-      const response = await fetch(`http://localhost:8090/api/v1/follows${endpoint}?followingid=${targetUserId}`, {
-        method: method,
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include' // 쿠키 포함
-      });
+      const method = isCurrentlyFollowing ? "DELETE" : "POST";
+      const endpoint = isCurrentlyFollowing ? "/unfollow" : "/follow";
+
+      const response = await fetch(
+        `http://localhost:8090/api/v1/follows${endpoint}?followingid=${targetUserId}`,
+        {
+          method: method,
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include", // 쿠키 포함
+        }
+      );
 
       if (!response.ok) {
-        throw new Error('Failed to toggle follow status');
+        throw new Error("Failed to toggle follow status");
       }
 
       // 상태 업데이트
       const updateFollowStatus = (users: User[]) =>
-        users.map(user =>
+        users.map((user) =>
           user.id === targetUserId
             ? { ...user, isFollowing: !isCurrentlyFollowing }
             : user
         );
 
-      if (activeTab === 'following') {
+      if (activeTab === "following") {
         setFollowing(updateFollowStatus(following));
       } else {
         setFollowers(updateFollowStatus(followers));
       }
     } catch (error) {
-      console.error('Failed to toggle follow status:', error);
+      console.error("Failed to toggle follow status:", error);
     }
   };
 
@@ -114,61 +132,85 @@ const UserFollower: React.FC<UserFollowerProps> = ({ isOpen, onClose, userId, in
   }, [isOpen, userId]);
 
   // 현재 탭에 따른 사용자 목록
-  const currentUsers = activeTab === 'followers' ? followers : following;
+  const currentUsers = activeTab === "followers" ? followers : following;
 
   // 검색어로 필터링된 사용자 목록
-  const filteredUsers = currentUsers.filter(user =>
-    user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    user.username.toLowerCase().includes(searchQuery.toLowerCase())
+  const filteredUsers = currentUsers.filter(
+    (user) =>
+      user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      user.status.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black bg-opacity-50 backdrop-blur-sm" onClick={onClose}></div>
-      
+      <div
+        className="absolute inset-0 bg-black bg-opacity-50 backdrop-blur-sm"
+        onClick={onClose}
+      ></div>
+
       <div className="relative bg-white rounded-xl w-full max-w-[400px] mx-4">
         <div className="flex items-center justify-between px-4 py-2 border-b">
           <button onClick={onClose} className="p-2 hover:opacity-50">
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
             </svg>
           </button>
           <div className="flex-1 text-center font-semibold">
-            {activeTab === 'followers' ? '팔로워' : '팔로우'}
+            {activeTab === "followers" ? "팔로워" : "팔로우"}
           </div>
           <div className="w-10"></div>
         </div>
 
         <div className="flex border-b">
-          <button 
-            onClick={() => setActiveTab('followers')}
+          <button
+            onClick={() => setActiveTab("followers")}
             className={`flex-1 text-sm font-medium py-3 ${
-              activeTab === 'followers' 
-                ? 'border-b border-black text-black' 
-                : 'text-gray-500'
+              activeTab === "followers"
+                ? "border-b border-black text-black"
+                : "text-gray-500"
             }`}
           >
             팔로워
           </button>
-          <button 
-            onClick={() => setActiveTab('following')}
+          <button
+            onClick={() => setActiveTab("following")}
             className={`flex-1 text-sm font-medium py-3 ${
-              activeTab === 'following' 
-                ? 'border-b border-black text-black' 
-                : 'text-gray-500'
+              activeTab === "following"
+                ? "border-b border-black text-black"
+                : "text-gray-500"
             }`}
           >
             팔로우
           </button>
         </div>
-        
+
         <div className="p-2">
           <div className="relative bg-gray-100 rounded-lg">
             <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <svg className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              <svg
+                className="h-4 w-4 text-gray-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
               </svg>
             </div>
             <input
@@ -180,7 +222,7 @@ const UserFollower: React.FC<UserFollowerProps> = ({ isOpen, onClose, userId, in
             />
           </div>
         </div>
-        
+
         <div className="overflow-y-auto max-h-[400px]">
           {loading ? (
             <div className="text-center py-6 text-gray-500 text-sm">
@@ -190,25 +232,25 @@ const UserFollower: React.FC<UserFollowerProps> = ({ isOpen, onClose, userId, in
             <div className="py-8 px-4">
               <div className="text-center">
                 <div className="mx-auto w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-3">
-                  <svg 
-                    xmlns="http://www.w3.org/2000/svg" 
-                    width="24" 
-                    height="24" 
-                    viewBox="0 0 24 24" 
-                    fill="none" 
-                    stroke="currentColor" 
-                    strokeWidth="2" 
-                    strokeLinecap="round" 
-                    strokeLinejoin="round" 
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                     className="text-gray-400"
                   >
-                    {activeTab === 'followers' ? (
+                    {activeTab === "followers" ? (
                       <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
                     ) : (
                       <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
                     )}
                     <circle cx="9" cy="7" r="4"></circle>
-                    {activeTab === 'following' && (
+                    {activeTab === "following" && (
                       <>
                         <circle cx="19" cy="11" r="2"></circle>
                         <path d="M19 8v1"></path>
@@ -220,23 +262,21 @@ const UserFollower: React.FC<UserFollowerProps> = ({ isOpen, onClose, userId, in
                   </svg>
                 </div>
                 <h3 className="text-lg font-semibold mb-1">
-                  {searchQuery 
-                    ? '검색 결과가 없습니다'
-                    : activeTab === 'followers'
-                      ? '아직 팔로워가 없습니다'
-                      : '아직 팔로우하는 사용자가 없습니다'
-                  }
+                  {searchQuery
+                    ? "검색 결과가 없습니다"
+                    : activeTab === "followers"
+                    ? "아직 팔로워가 없습니다"
+                    : "아직 팔로우하는 사용자가 없습니다"}
                 </h3>
                 <p className="text-gray-500 text-sm mb-4">
-                  {searchQuery 
-                    ? '다른 검색어를 시도해보세요'
-                    : activeTab === 'followers'
-                      ? '다른 사용자들이 회원님을 팔로우하면 여기에 표시됩니다.'
-                      : '관심 있는 사용자를 팔로우하면 여기에 표시됩니다.'
-                  }
+                  {searchQuery
+                    ? "다른 검색어를 시도해보세요"
+                    : activeTab === "followers"
+                    ? "다른 사용자들이 회원님을 팔로우하면 여기에 표시됩니다."
+                    : "관심 있는 사용자를 팔로우하면 여기에 표시됩니다."}
                 </p>
-                {!searchQuery && activeTab === 'following' && (
-                  <button 
+                {!searchQuery && activeTab === "following" && (
+                  <button
                     className="px-4 py-2 bg-black text-white rounded-md text-sm font-medium"
                     onClick={() => {
                       onClose();
@@ -250,52 +290,60 @@ const UserFollower: React.FC<UserFollowerProps> = ({ isOpen, onClose, userId, in
             </div>
           ) : (
             filteredUsers.map((user) => (
-              <div key={user.id} className="flex items-center justify-between px-4 py-2 hover:bg-gray-50">
+              <div
+                key={user.id}
+                className="flex items-center justify-between px-4 py-2 hover:bg-gray-50"
+              >
                 <div className="flex items-center flex-1 min-w-0">
                   <div className="relative h-11 w-11 rounded-full overflow-hidden border">
                     <div className="absolute inset-0 bg-gray-200 flex items-center justify-center">
-                      {user.imageUrl ? (
+                      {user.currentProfilePhoto?.url ? (
                         <Image
-                          src={user.imageUrl}
+                          src={user.currentProfilePhoto.url}
                           alt={user.name}
                           fill
                           className="object-cover"
                           onError={(e) => {
-                            e.currentTarget.style.display = 'none';
+                            e.currentTarget.style.display = "none";
                           }}
                         />
-                      ) : null}
-                      <span className="text-sm font-medium text-gray-600">
-                        {user.name.charAt(0)}
-                      </span>
+                      ) : (
+                        <span className="text-sm font-medium text-gray-600">
+                          {user.name.charAt(0)}
+                        </span>
+                      )}
                     </div>
                   </div>
                   <div className="ml-3 min-w-0">
-                    <p className="text-sm font-semibold truncate">{user.username}</p>
-                    <p className="text-sm text-gray-500 truncate">{user.name}</p>
+                    <p className="text-sm font-semibold truncate">
+                      {user.name}
+                    </p>
+                    <p className="text-sm text-gray-500 truncate">
+                      {user.status}
+                    </p>
                   </div>
                 </div>
-                {activeTab === 'followers' ? (
+                {activeTab === "followers" ? (
                   <button
                     onClick={() => handleFollowToggle(user.id)}
                     className={`ml-2 text-sm font-semibold px-4 py-1 rounded-md transition-colors ${
                       user.isFollowing
-                        ? 'bg-gray-100 text-gray-900 hover:bg-gray-200'
-                        : 'bg-blue-500 text-white hover:bg-blue-600'
+                        ? "bg-gray-100 text-gray-900 hover:bg-gray-200"
+                        : "bg-blue-500 text-white hover:bg-blue-600"
                     }`}
                   >
-                    {user.isFollowing ? '팔로잉' : '팔로우'}
+                    {user.isFollowing ? "팔로잉" : "팔로우"}
                   </button>
                 ) : (
                   <button
                     onClick={() => handleFollowToggle(user.id)}
                     className={`ml-2 text-sm font-semibold px-4 py-1 rounded-md transition-colors ${
                       user.isFollowing
-                        ? 'bg-gray-100 text-gray-900 hover:bg-gray-200'
-                        : 'bg-blue-500 text-white hover:bg-blue-600'
+                        ? "bg-gray-100 text-gray-900 hover:bg-gray-200"
+                        : "bg-blue-500 text-white hover:bg-blue-600"
                     }`}
                   >
-                    {user.isFollowing ? '팔로잉' : '팔로우'}
+                    {user.isFollowing ? "팔로잉" : "팔로우"}
                   </button>
                 )}
               </div>

--- a/frontend/src/components/user_follower.tsx
+++ b/frontend/src/components/user_follower.tsx
@@ -1,21 +1,24 @@
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
+import axios from "axios"; // axios 임포트 필요
 
 interface UserFollowerProps {
   isOpen: boolean;
   onClose: () => void;
-  userId?: string; // 현재 보고 있는 프로필의 사용자 ID
-  initialTab?: "followers" | "following"; // 초기 선택 탭
+  userId?: string; // 타겟 유저 ID
+  initialTab?: "followers" | "following"; // 초기 탭
 }
 
+// 백엔드 UserFollowDto에 맞춰 User 인터페이스 정의
 interface User {
   id: number;
   name: string;
-  status: string;
+  status: string; // 예: ACTIVE, DELETED
   currentProfilePhoto?: {
+    // 프로필 사진 정보 (있을 수도, 없을 수도)
     url: string;
   } | null;
-  isFollowing?: boolean;
+  isFollowing?: boolean; // 로그인한 유저가 이 목록의 유저를 팔로우하는지 여부 (백엔드 지원 필요)
 }
 
 const UserFollower: React.FC<UserFollowerProps> = ({
@@ -32,68 +35,228 @@ const UserFollower: React.FC<UserFollowerProps> = ({
   const [following, setFollowing] = useState<User[]>([]);
   const [loading, setLoading] = useState(false);
 
-  // 팔로워와 팔로잉 목록을 가져오는 함수
+  // 팔로워와 팔로잉 목록을 가져오는 함수 (404 오류 해결)
   const fetchFollowData = async () => {
-    if (!userId) return;
+    if (!userId || !isOpen) return;
 
     setLoading(true);
     try {
-      // 팔로잉 목록 가져오기 (내가 팔로우하는 사람들)
-      const followingResponse = await fetch(
-        `http://localhost:8090/api/v1/follows/members/${userId}/followings`,
-        {
-          credentials: "include",
-        }
+      const baseURL =
+        process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8090";
+
+      // --- 엔드포인트 구성 수정: activeTab 값에 따라 정확한 백엔드 경로 사용 ---
+      const endpoint = `${baseURL}/api/v1/follows/members/${userId}/${
+        activeTab === "followers" ? "followers" : "followings"
+      }`; // <-- 404 오류 해결!
+
+      console.log(
+        `Workspaceing data for tab: ${activeTab} from endpoint: ${endpoint}. Relying on cookies.`
       );
 
-      // 팔로워 목록 가져오기 (나를 팔로우하는 사람들)
-      const followersResponse = await fetch(
-        `http://localhost:8090/api/v1/follows/members/${userId}/followers`,
-        {
-          credentials: "include",
-        }
-      );
+      const response = await axios.get(endpoint, {
+        withCredentials: true, // 브라우저가 쿠키 자동 포함
+        // headers: { /* Authorization 헤더 없음 */ } // GET 요청에는 Authorization 헤더 불필요 (백엔드 설정에 따라)
+      });
 
-      const followingData = await followingResponse.json();
-      const followersData = await followersResponse.json();
+      const data = response.data; // axios는 응답 본문을 .data에 담음
 
-      console.log("Following data (내가 팔로우하는 사람들):", followingData);
-      console.log("Followers data (나를 팔로우하는 사람들):", followersData);
+      console.log(`Workspaceed data for ${activeTab}:`, data);
 
-      // 상태 업데이트를 올바른 배열에 할당
-      if (followersResponse.ok) {
-        setFollowers(followersData || []); // 나를 팔로우하는 사람들
-      }
-
-      if (followingResponse.ok) {
-        setFollowing(followingData || []); // 내가 팔로우하는 사람들
+      // 받아온 데이터 구조에 맞춰 상태 업데이트
+      if (activeTab === "following") {
+        // 혹시 목록에 자신의 ID가 포함된다면 제외 (선택 사항)
+        setFollowing(
+          (data || []).filter((user: User) => user.id !== Number(userId))
+        );
+        setFollowers([]); // 다른 목록 비움
+      } else {
+        // activeTab === "followers"
+        // 혹시 목록에 자신의 ID가 포함된다면 제외 (선택 사항)
+        setFollowers(
+          (data || []).filter((user: User) => user.id !== Number(userId))
+        );
+        setFollowing([]); // 다른 목록 비움
       }
     } catch (error) {
       console.error("Failed to fetch follow data:", error);
-      setFollowers([]);
-      setFollowing([]);
+      if (activeTab === "following") {
+        setFollowing([]);
+      } else {
+        setFollowers([]);
+      }
+      // --- 오류 메시지 표시 부분 수정 (404 처리 및 [object Object] 방지) ---
+      // AxiosError인지 확인하고, response 객체가 있는지 확인합니다.
+      if (axios.isAxiosError(error) && error.response) {
+        // <-- error.response 체크 추가
+        // error.response가 있다면 data와 status에 안전하게 접근 가능합니다.
+        // error.response.data가 객체일 경우 문자열로 변환하여 [object Object] 방지
+        const errorDataString =
+          typeof error.response.data === "object"
+            ? JSON.stringify(error.response.data)
+            : error.response.data;
+        const errorMessage =
+          errorDataString || error.message || "알 수 없는 오류가 발생했습니다.";
+
+        if (error.response.status === 401) {
+          alert("인증 정보가 만료되었습니다. 다시 로그인 해주세요.");
+          // router.push("/members/login");
+        } else if (error.response.status === 404) {
+          console.error(
+            `404 Error: Endpoint not found. Check URL: ${error.config?.url}`,
+            error
+          ); // 전체 에러 로깅
+          alert(
+            `요청한 팔로워/팔로잉 목록을 찾을 수 없습니다: ${errorMessage}`
+          ); // 사용자 정의 메시지와 백엔드 오류 메시지 함께 표시
+        }
+        // 다른 4xx (400 등) 또는 5xx 에러는 여기서 추가 처리 가능
+      } else {
+        // AxiosError가 아니거나 response 객체가 없는 경우 (네트워크 오류 등)
+        const errorMessage =
+          error instanceof Error ? error.message : String(error); // 'error' unknown 타입 처리
+        console.error("목록 로딩 중 오류 발생:", error); // 전체 에러 로깅
+        alert(`목록 로딩 중 오류가 발생했습니다: ${errorMessage}`); // 오류 메시지 표시
+      }
     } finally {
       setLoading(false);
     }
   };
 
-  // 컴포넌트가 마운트되거나 userId가 변경될 때만 데이터를 가져옴
+  // 팔로우/언팔로우 토글 함수 (500 오류 발생 시 백엔드 디버깅 필요)
+  const handleFollowToggle = async (targetUserId: number) => {
+    // 백엔드 컨트롤러가 Authorization 헤더를 요구하므로 토큰이 localStorage에 있어야 합니다.
+    const token = localStorage.getItem("accessToken");
+    if (!token) {
+      alert("로그인이 필요합니다.");
+      // router.push("/members/login");
+      return; // 토큰 없으면 요청 중단
+    }
+
+    // 현재 목록에서 대상 유저 찾기
+    const userToToggle = (
+      activeTab === "followers" ? followers : following
+    ).find((u) => u.id === targetUserId);
+    if (!userToToggle) {
+      console.warn(
+        "Attempted to toggle follow for user not in current list:",
+        targetUserId
+      );
+      // fetchFollowData(); // 목록 새로고침 시도 (선택 사항)
+      return;
+    }
+
+    // isFollowing 상태는 백엔드에서 정확히 내려온다는 가정 하에 토글 액션 결정
+    const isCurrentlyFollowingStatus = userToToggle.isFollowing; // isFollowing 필드가 DTO에 있어야 함
+
+    try {
+      const apiBaseUrl =
+        process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8090";
+      const method = isCurrentlyFollowingStatus ? "DELETE" : "POST"; // 상태에 따라 메소드 결정
+      const action = isCurrentlyFollowingStatus ? "unfollow" : "follow"; // 상태에 따라 액션 경로 결정
+      // 백엔드 컨트롤러 엔드포인트: POST /follow, DELETE /unfollow. 모두 쿼리 파라미터 'followingid' 사용.
+      const url = `${apiBaseUrl}/api/v1/follows/${action}?followingid=${targetUserId}`;
+
+      console.log(
+        `Attempting ${method} request to ${url}. Adding Authorization header.`
+      );
+
+      const response = await axios({
+        method: method, // 결정된 HTTP 메소드
+        url: url, // 결정된 URL
+        withCredentials: true, // 쿠키 포함
+        headers: {
+          "Content-Type": "application/json", // Content-Type 유지
+          Authorization: `Bearer ${token}`, // --- Authorization 헤더 추가 (컨트롤러 요구) ---
+        },
+        data: undefined, // 본문 데이터 없음 (쿼리 파라미터 사용)
+      });
+
+      console.log("Follow Toggle response:", response.data);
+      alert(response.data || "상태 변경 성공"); // 백엔드 응답 메시지 알림
+
+      fetchFollowData(); // 상태 변경 후 목록 새로고침
+    } catch (error) {
+      console.error("Error toggling follow state:", error);
+      // AxiosError인지 확인하고, response 객체가 있는지 확인합니다.
+      if (axios.isAxiosError(error) && error.response) {
+        // <-- error.response 체크 추가
+        // error.response가 있다면 data와 status에 안전하게 접근 가능합니다.
+        // error.response.data가 객체일 경우 문자열로 변환하여 [object Object] 방지
+        const errorDataString =
+          typeof error.response.data === "object"
+            ? JSON.stringify(error.response.data)
+            : error.response.data;
+        const errorMessage =
+          errorDataString || error.message || "알 수 없는 오류가 발생했습니다.";
+        alert(errorMessage);
+
+        if (error.response.status === 401) {
+          alert(
+            "인증 정보가 만료되었습니다. 세션이 만료되었습니다. 다시 로그인 해주세요."
+          );
+          // 필요시 로그인 페이지로 리다이렉트
+          // router.push("/members/login");
+        } else if (
+          error.response.status >= 400 &&
+          error.response.status < 500
+        ) {
+          // 4xx 클라이언트 에러 (백엔드 로직 오류 등)
+          console.warn(
+            `Toggle failed (Client Error ${error.response.status}):`,
+            errorMessage
+          );
+          // alert(errorMessage); // 이미 위에서 alert 함
+          fetchFollowData(); // 상태 동기화 위해 목록 다시 가져오기
+        } else if (error.response.status >= 500) {
+          // 5xx 서버 에러 처리
+          console.error(
+            `Toggle failed (Server Error ${error.response.status}):`,
+            errorMessage
+          );
+          // alert(errorMessage); // 이미 위에서 alert 함
+          fetchFollowData(); // 목록 다시 가져오기
+        }
+      } else {
+        // AxiosError가 아니거나 response 객체가 없는 경우 (예: 네트워크 오류)
+        const errorMessage =
+          error instanceof Error ? error.message : String(error); // 'error' unknown 타입 해결 및 메시지 처리
+        console.error("Toggle failed (Non-Axios or No Response Error):", error);
+        alert(`팔로우 상태 변경 중 오류가 발생했습니다: ${errorMessage}`);
+      }
+    }
+  };
+
+  // 모달 상태, userId, activeTab 변경 시 데이터 가져오기
   useEffect(() => {
+    console.log(
+      `Effect triggered in UserFollower - isOpen: ${isOpen}, userId: ${userId}, activeTab: ${activeTab}`
+    );
     if (isOpen && userId) {
       fetchFollowData();
+    } else {
+      // 모달 닫히거나 userId 없을 때 목록 비움
+      setFollowers([]);
+      setFollowing([]);
     }
-  }, [isOpen, userId]);
+    // activeTab 변경 시 fetchFollowData 다시 호출하도록 의존성 추가
+  }, [isOpen, userId, activeTab]);
 
-  // 현재 탭에 따른 사용자 목록을 교체
-  const currentUsers = activeTab === "followers" ? following : followers;
+  // 현재 활성화된 탭에 따라 표시할 사용자 목록 선택
+  const currentUsers = activeTab === "followers" ? followers : following;
 
-  // 검색어로 필터링된 사용자 목록
+  // 검색어로 사용자 목록 필터링
   const filteredUsers = currentUsers.filter((user) =>
     user.name.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
+  console.log(
+    `Rendering list for activeTab: ${activeTab}, Filtered list count: ${filteredUsers.length}`
+  );
+
+  // 모달이 열려있지 않으면 아무것도 렌더링하지 않음
   if (!isOpen) return null;
 
+  // --- JSX 렌더링 시작 ---
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div
@@ -101,8 +264,12 @@ const UserFollower: React.FC<UserFollowerProps> = ({
         onClick={onClose}
       ></div>
 
+      {/* 모달 본문 */}
       <div className="relative bg-white rounded-xl w-full max-w-[400px] mx-4">
+        {/* 헤더 (닫기 버튼, 탭 이름) */}
+        {/* ... (닫기 버튼, 탭 이름 표시 div, 빈 div) ... */}
         <div className="flex items-center justify-between px-4 py-2 border-b">
+          {/* 닫기 버튼 */}
           <button onClick={onClose} className="p-2 hover:opacity-50">
             <svg
               className="w-6 h-6"
@@ -118,12 +285,16 @@ const UserFollower: React.FC<UserFollowerProps> = ({
               />
             </svg>
           </button>
+          {/* 탭 이름 */}
           <div className="flex-1 text-center font-semibold">
-            {activeTab === "followers" ? "팔로워" : "팔로우"}
+            {activeTab === "followers" ? "팔로워" : "팔로잉"}{" "}
+            {/* "팔로우" 대신 "팔로잉"이 맞습니다 */}
           </div>
-          <div className="w-10"></div>
+          <div className="w-10"></div> {/* 우측 여백 */}
         </div>
 
+        {/* 탭 버튼 */}
+        {/* ... (팔로워/팔로잉 탭 버튼) ... */}
         <div className="flex border-b">
           <button
             onClick={() => setActiveTab("followers")}
@@ -133,7 +304,8 @@ const UserFollower: React.FC<UserFollowerProps> = ({
                 : "text-gray-500"
             }`}
           >
-            팔로워
+            {" "}
+            팔로워{" "}
           </button>
           <button
             onClick={() => setActiveTab("following")}
@@ -143,10 +315,13 @@ const UserFollower: React.FC<UserFollowerProps> = ({
                 : "text-gray-500"
             }`}
           >
-            팔로우
+            {" "}
+            팔로잉{" "}
           </button>
         </div>
 
+        {/* 검색 입력 필드 */}
+        {/* ... (검색 입력 필드) ... */}
         <div className="p-2">
           <div className="relative bg-gray-100 rounded-lg">
             <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -174,14 +349,17 @@ const UserFollower: React.FC<UserFollowerProps> = ({
           </div>
         </div>
 
+        {/* 목록 영역 (로딩, 빈 목록, 사용자 목록) */}
         <div className="overflow-y-auto max-h-[400px]">
           {loading ? (
             <div className="text-center py-6 text-gray-500 text-sm">
-              로딩 중...
+              {" "}
+              로딩 중...{" "}
             </div>
           ) : filteredUsers.length === 0 ? (
             <div className="py-8 px-4">
               <div className="text-center">
+                {/* 빈 목록 아이콘 */}
                 <div className="mx-auto w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-3">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -196,22 +374,24 @@ const UserFollower: React.FC<UserFollowerProps> = ({
                     className="text-gray-400"
                   >
                     {activeTab === "followers" ? (
-                      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
+                      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-2 4v2"></path>
                     ) : (
                       <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
-                    )}
+                    )}{" "}
+                    {/* Fix d attribute for followers */}
                     <circle cx="9" cy="7" r="4"></circle>
                     {activeTab === "following" && (
                       <>
-                        <circle cx="19" cy="11" r="2"></circle>
-                        <path d="M19 8v1"></path>
-                        <path d="M19 13v1"></path>
-                        <path d="M16 11h1"></path>
-                        <path d="M21 11h1"></path>
+                        {" "}
+                        <circle cx="19" cy="11" r="2"></circle>{" "}
+                        <path d="M19 8v1"></path> <path d="M19 13v1"></path>{" "}
+                        <path d="M16 11h1"></path> <path d="M21 11h1"></path>{" "}
                       </>
                     )}
                   </svg>
                 </div>
+
+                {/* 빈 목록 텍스트 */}
                 <h3 className="text-lg font-semibold mb-1">
                   {searchQuery
                     ? "검색 결과가 없습니다"
@@ -226,12 +406,12 @@ const UserFollower: React.FC<UserFollowerProps> = ({
                     ? "다른 사용자들이 회원님을 팔로우하면 여기에 표시됩니다."
                     : "관심 있는 사용자를 팔로우하면 여기에 표시됩니다."}
                 </p>
+                {/* 팔로잉 탭에서 사용자 찾아보기 버튼 */}
                 {!searchQuery && activeTab === "following" && (
                   <button
                     className="px-4 py-2 bg-black text-white rounded-md text-sm font-medium"
                     onClick={() => {
-                      onClose();
-                      // 이 부분은 필요에 따라 다른 페이지로 네비게이션 추가 가능
+                      onClose(); /* Optional: Add navigation */
                     }}
                   >
                     사용자 찾아보기
@@ -240,14 +420,17 @@ const UserFollower: React.FC<UserFollowerProps> = ({
               </div>
             </div>
           ) : (
+            // --- 목록 항목 렌더링 ---
             filteredUsers.map((user) => (
               <div
                 key={user.id}
                 className="flex items-center justify-between px-4 py-2 hover:bg-gray-50"
               >
+                {/* 유저 아바타, 이름, 상태 */}
                 <div className="flex items-center flex-1 min-w-0">
                   <div className="relative h-11 w-11 rounded-full overflow-hidden border">
                     <div className="absolute inset-0 bg-gray-200 flex items-center justify-center">
+                      {/* 프로필 사진 또는 이니셜 표시 */}
                       {user.currentProfilePhoto?.url ? (
                         <Image
                           src={user.currentProfilePhoto.url}
@@ -260,43 +443,36 @@ const UserFollower: React.FC<UserFollowerProps> = ({
                         />
                       ) : (
                         <span className="text-sm font-medium text-gray-600">
-                          {user.name.charAt(0)}
+                          {" "}
+                          {user.name.charAt(0)}{" "}
                         </span>
                       )}
                     </div>
                   </div>
                   <div className="ml-3 min-w-0">
                     <p className="text-sm font-semibold truncate">
-                      {user.name}
+                      {" "}
+                      {user.name}{" "}
                     </p>
                     <p className="text-sm text-gray-500 truncate">
-                      {user.status}
+                      {" "}
+                      {user.status}{" "}
                     </p>
                   </div>
                 </div>
-                {activeTab === "followers" ? (
-                  <button
-                    onClick={() => handleFollowToggle(user.id)}
-                    className={`ml-2 text-sm font-semibold px-4 py-1 rounded-md transition-colors ${
-                      user.isFollowing
-                        ? "bg-gray-100 text-gray-900 hover:bg-gray-200"
-                        : "bg-blue-500 text-white hover:bg-blue-600"
-                    }`}
-                  >
-                    {user.isFollowing ? "팔로잉" : "팔로우"}
-                  </button>
-                ) : (
-                  <button
-                    onClick={() => handleFollowToggle(user.id)}
-                    className={`ml-2 text-sm font-semibold px-4 py-1 rounded-md transition-colors ${
-                      user.isFollowing
-                        ? "bg-gray-100 text-gray-900 hover:bg-gray-200"
-                        : "bg-blue-500 text-white hover:bg-blue-600"
-                    }`}
-                  >
-                    {user.isFollowing ? "팔로잉" : "팔로우"}
-                  </button>
-                )}
+
+                {/* 팔로우/언팔로우 버튼 */}
+                <button // 중복 조건문 2 (8062bc7 시점 코드 유지)
+                  onClick={() => handleFollowToggle(user.id)} // handleFollowToggle 호출
+                  className={`ml-2 text-sm font-semibold px-4 py-1 rounded-md transition-colors ${
+                    user.isFollowing // isFollowing에 따라 스타일 결정
+                      ? "bg-gray-100 text-gray-900 hover:bg-gray-200" // 팔로잉 상태 스타일
+                      : "bg-blue-500 text-white hover:bg-blue-600" // 팔로우 안 하는 상태 스타일
+                  }`}
+                >
+                  {user.isFollowing ? "팔로잉" : "팔로우"}{" "}
+                  {/* isFollowing에 따라 텍스트 결정 */}
+                </button>
               </div>
             ))
           )}


### PR DESCRIPTION
## 작업 내용

- 팔로우, 팔로워가 0일때의 팔로우 관련 팝업이 발생하지 않는 문제 발생
- 해결하기 위해 스크립트 수정이 필요

## 할 일

### 25-04-22
- [1] 팔로워/팔로잉이 없을때 빈 배열 [] 이 오는 문제를 제대로 처리하도록 수정
- [2] 팔로워/팔로잉이 없을때 팝업 트리거가 비활성화될 수 있는 문제 해결

### 25-04-23
- [3] 팔로워/팔로잉 API 테스트 진행 (CURL 진행)
- [4] 팔로워/팔로잉이 정확한 위치에 표시되는지 확인 후 수정

## 오류 원인

### 25-04-22
- 컴포넌트가 마운트될 떄 useEffect에서 isOpen && userId 조건으로 데이터를 가져오고 있음
팝업 오픈 여부와 관련된 상태 관리가 잘못되고 있음
- 회원가입 페이지가 제대로 렌더링되지 않는 문제 발생
members/signup/page.tsx에서 handleSignUp 함수가 두 번 정의된 충돌 해결 및 중괄호 구문 오류 해결

- 회원가입 진행 시 "서버와의 통신 오류 발생" - 새 사용자 저장하는 과정에서 refresh Token을 생성할때 아직 저장되지 않은 사용자의 ID를 사용하고자하는 원인

### 25-04-23
- 팔로워/팔로잉이 서로 반대의 위치에서 표시되는 문제 확인

## 해결과정

- isOpen && userId 대신 isOpen 일 때만 데이터를 불러오도록 수정
- 응답 데이터가 배열이 아닐 경우의 대체 코드 필요
- API 호출을 병렬로 처리
- 백엔드에서 메소드 중복 문제 해결
- 백엔드에서 status 중복 선언 문제 해결
- 사용자 객체를 먼저 저장하여 DB에서 ID를 할당받고 refresh token을 생성하는 순서로 수정
- 회원가입 페이지 뚜렷하지 않은 글씨색 수정 (Ivory -> Black)

## 스크린샷 (필요시)

- ⚠️문제상황

![Image](https://github.com/user-attachments/assets/3c4080e0-b684-4e36-bcaf-4e3bd9a1e9b7)

- ✅해결상황

### 25-04-23
팔로워/팔로잉 알맞은 탭에서 출력됨을 확인 완료

![Image](https://github.com/user-attachments/assets/3382f77f-72f2-431a-bbcc-52ef088d0ad9)
![Image](https://github.com/user-attachments/assets/d23f9505-be8b-4ced-b7a9-5b8b7c03b761)
![Image](https://github.com/user-attachments/assets/5145337a-5eb4-453a-919f-3a28b357518b)

### 25-04-23_(2)
팔로우중인 유저 확인

![Image](https://github.com/user-attachments/assets/379ea6c7-5bb0-49e0-90b9-c58bfb453b07)

---
Closes #129 